### PR TITLE
Updated servie dependency which was causing errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,9 +1254,9 @@
       "dev": true
     },
     "servie": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/servie/-/servie-4.2.1.tgz",
-      "integrity": "sha512-MoGLGNFE06XEVmnYdlhvnv6uZis7E4BEJAJVEIJ9AdF3n+uabf4/GFewI26wvDUce8r7pHMRk0MPaRU2FTXPnQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/servie/-/servie-4.3.1.tgz",
+      "integrity": "sha512-4aFazTOWZbX2sXxe0cOoKK62s6Ty8Sz/9yiPr3JhP1poxBZviyU9/cSnD0lUwVmJlOjKk+yA8/uRgyMCgVnyBA==",
       "requires": {
         "@servie/events": "^1.0.0",
         "byte-length": "^1.0.2"


### PR DESCRIPTION
I was getting errors from http response headers that had numeric values. Turns out this was fixed in the servie package a little while back, just needed to update it from `4.2.1` to `4.3.1`