### PR TITLE
Fixed authentication route

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,11 @@
 const authUrl = 'https://api.ouraring.com/oauth'
 const baseUrl = 'https://api.ouraring.com/v1'
+const authorizeUrl = 'https://cloud.ouraring.com/oauth'
 module.exports = {
   authUrl: authUrl,
   baseUrl: baseUrl,
   accessTokenUri: authUrl + '/token',
-  authorizationUri: authUrl + '/authorize',
+  authorizationUri: authorizeUrl + '/authorize',
   authorizationGrants: ['credentials'],
   scopes: ['personal', 'daily']
 }


### PR DESCRIPTION
Oura recently changed their authentication route from api.ouraring.com to cloud.ouraring.com 

Here's a link to the documentation https://cloud.ouraring.com/docs/authentication